### PR TITLE
replace image relpath with abspath

### DIFF
--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -520,7 +520,8 @@ class RemarkableWindow(Window):
         start, end = self.text_buffer.get_bounds()
         text = self.text_buffer.get_text(start, end, False)
         text = self.text_buffer.get_text(self.text_buffer.get_start_iter(), self.text_buffer.get_end_iter(), False)
-        text = re.sub(r'(\!\[.*\]\()([^/].*\))',r'\1{}/\2'.format(os.path.dirname(self.name)),text)
+        dirname = os.path.dirname(self.name)
+        text = re.sub(r'(\!\[.*?\]\()([^/][^:]*?\))', lambda m, dirname=dirname: m.group(1) + os.path.join(dirname, m.group(2)), text)
         try:
             html_middle = markdown.markdown(text, self.default_extensions)
         except:
@@ -889,7 +890,8 @@ class RemarkableWindow(Window):
         tf_name = tf.name
 
         text = self.text_buffer.get_text(self.text_buffer.get_start_iter(), self.text_buffer.get_end_iter(), False)
-        text = re.sub(r'(\!\[.*\]\()([^/].*\))',r'\1{}/\2'.format(os.path.dirname(self.name)),text)
+        dirname = os.path.dirname(self.name)
+        text = re.sub(r'(\!\[.*?\]\()([^/][^:]*?\))', lambda m, dirname=dirname: m.group(1) + os.path.join(dirname, m.group(2)), text)
         try:
             html_middle = markdown.markdown(text, self.default_extensions)
         except:

--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -520,6 +520,7 @@ class RemarkableWindow(Window):
         start, end = self.text_buffer.get_bounds()
         text = self.text_buffer.get_text(start, end, False)
         text = self.text_buffer.get_text(self.text_buffer.get_start_iter(), self.text_buffer.get_end_iter(), False)
+        text = re.sub(r'(\!\[.*\]\()([^/].*\))',r'\1{}/\2'.format(os.path.dirname(self.name)),text)
         try:
             html_middle = markdown.markdown(text, self.default_extensions)
         except:
@@ -888,6 +889,7 @@ class RemarkableWindow(Window):
         tf_name = tf.name
 
         text = self.text_buffer.get_text(self.text_buffer.get_start_iter(), self.text_buffer.get_end_iter(), False)
+        text = re.sub(r'(\!\[.*\]\()([^/].*\))',r'\1{}/\2'.format(os.path.dirname(self.name)),text)
         try:
             html_middle = markdown.markdown(text, self.default_extensions)
         except:


### PR DESCRIPTION
for #42 #45 
get current file path from `self.name`
`re` matches every image which uses relative path(not start with '/')
substitute in `preview_browser` and `export_pdf`
