### PR TITLE
Save last used zoom level to settings.

### DIFF
--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -207,7 +207,8 @@ class RemarkableWindow(Window):
             self.remarkable_settings['style'] = "github"
             self.remarkable_settings['toolbar'] = True
             self.remarkable_settings['vertical'] = False
-            self.remarkable_settings['word-wrap'] = True                    
+            self.remarkable_settings['word-wrap'] = True
+            self.remarkable_settings['zoom-level'] = 1
             settings_file = open(self.settings_path, 'w')
             settings_file.write(str(self.remarkable_settings))
             settings_file.close()
@@ -261,6 +262,9 @@ class RemarkableWindow(Window):
         if self.remarkable_settings['vertical'] == True:
             # Switch to vertical layout
             self.builder.get_object("menuitem_vertical_layout").set_active(True)
+
+        if 'zoom-level' in self.remarkable_settings:
+            self.live_preview.set_zoom_level(self.remarkable_settings['zoom-level'])
 
         # Try to load the previously chosen font, may fail as font may not exist, ect.
         try:
@@ -625,10 +629,14 @@ class RemarkableWindow(Window):
 
     def on_toolbutton_zoom_in_clicked(self, widget):
         self.live_preview.zoom_in()
+        self.remarkable_settings['zoom-level'] = self.live_preview.get_zoom_level()
+        self.write_settings()
         self.scrollPreviewToFix(self)
 
     def on_toolbutton_zoom_out_clicked(self, widget):
         self.live_preview.zoom_out()
+        self.remarkable_settings['zoom-level'] = self.live_preview.get_zoom_level()
+        self.write_settings()
         self.scrollPreviewToFix(self)
 
     def redo(self, widget):


### PR DESCRIPTION
@jamiemcg btw, why is there `zoom_in` when moving to handwritten style, and `zoom_out` after `live_preview.connect`?
If they're not needed, I can remove them in this PR. 