### PR TITLE
Quick Fix to Issue #160 - Replace MathJax CDN

### DIFF
--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -84,7 +84,7 @@ class RemarkableWindow(Window):
         self.default_html_start = '<!doctype HTML><html><head><meta charset="utf-8"><title>Made with Remarkable!</title><link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/github.min.css">'
         self.default_html_start += "<style type='text/css'>" + styles.css + "</style>"
         self.default_html_start += "</head><body id='MathPreviewF'>"
-        self.default_html_end = '<script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js"></script><script>hljs.initHighlightingOnLoad();</script><script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><script type="text/javascript">MathJax.Hub.Config({"showProcessingMessages" : false,"messageStyle" : "none","tex2jax": { inlineMath: [ [ "$", "$" ] ] }});</script></body></html>'
+        self.default_html_end = '<script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js"></script><script>hljs.initHighlightingOnLoad();</script><script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><script type="text/javascript">MathJax.Hub.Config({"showProcessingMessages" : false,"messageStyle" : "none","tex2jax": { inlineMath: [ [ "$", "$" ] ] }});</script></body></html>'
         
         self.remarkable_settings = {}
 


### PR DESCRIPTION
MathJax' CDN is shutting down / changing, requiring the use of a different URL.

https://www.mathjax.org/cdn-shutting-down/

See the discussion in Issue #160 for more information. I don't necessarily intend for this PR to be merged, but I do think that it could help raise awareness of the issue, and of the other potential solutions too.