### PR TITLE
Upgrading to Webkit2

### DIFF
--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -75,6 +75,7 @@ class RemarkableWindow(Window):
 
         self.is_fullscreen = False
         self.editor_position = 0
+        self.zoom_steps = 0.1
         self.homeDir = os.environ['HOME']
         self.path = os.path.join(self.homeDir, ".remarkable/")
         self.settings_path = os.path.join(self.path, "remarkable.settings")
@@ -680,13 +681,13 @@ class RemarkableWindow(Window):
         self.redo(self)
 
     def on_toolbutton_zoom_in_clicked(self, widget):
-        self.live_preview.zoom_in()
+        self.live_preview.set_zoom_level((1+self.zoom_steps)*self.live_preview.get_zoom_level())
         self.remarkable_settings['zoom-level'] = self.live_preview.get_zoom_level()
         self.write_settings()
         self.scrollPreviewToFix(self)
 
     def on_toolbutton_zoom_out_clicked(self, widget):
-        self.live_preview.zoom_out()
+        self.live_preview.set_zoom_level((1-self.zoom_steps)*self.live_preview.get_zoom_level())
         self.remarkable_settings['zoom-level'] = self.live_preview.get_zoom_level()
         self.write_settings()
         self.scrollPreviewToFix(self)

--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -24,10 +24,10 @@
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('GtkSource', '3.0')
-gi.require_version('WebKit', '3.0')
+gi.require_version('WebKit2', '4.0')
 
 from bs4 import BeautifulSoup
-from gi.repository import Gdk, Gtk, GtkSource, Pango, WebKit
+from gi.repository import Gdk, Gtk, GtkSource, Pango, WebKit2
 from locale import gettext as _
 from urllib.request import urlopen
 import markdown
@@ -116,8 +116,8 @@ class RemarkableWindow(Window):
         self.text_view.set_wrap_mode(Gtk.WrapMode.WORD)
         self.text_view.connect('key-press-event', self.cursor_ctrl_arrow_rtl_fix)
 
-        self.live_preview = WebKit.WebView()
-        self.live_preview.connect("console-message", self._javascript_console_message) # Suppress .js output
+        self.live_preview = WebKit2.WebView()
+        #self.live_preview.connect("console-message", self._javascript_console_message) # Suppress .js output
 
         self.scrolledwindow_text_view = Gtk.ScrolledWindow()
         self.scrolledwindow_text_view.add(self.text_view)
@@ -1549,7 +1549,7 @@ class RemarkableWindow(Window):
         html = self.default_html_start + html_middle + self.default_html_end
 
         # Update the display, supporting relative paths to local images
-        self.live_preview.load_string(html, "text/html", "utf-8", "file://{}".format(os.path.abspath(self.name)))
+        self.live_preview.load_html(html, "file://{}".format(os.path.abspath(self.name)))
 
     """
         This function suppresses the messages from the WebKit (live preview) console

--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -32,6 +32,7 @@ from locale import gettext as _
 from urllib.request import urlopen
 import markdown
 import os
+import sys
 import pdfkit
 import re, subprocess, datetime, os, webbrowser, _thread, sys, locale
 import tempfile
@@ -386,7 +387,7 @@ class RemarkableWindow(Window):
         Launches a new instance of Remarkable
     """
     def new(self, widget):
-        subprocess.Popen("remarkable")
+        subprocess.Popen(sys.argv[0])
 
     def on_menuitem_open_activate(self, widget):
         self.open(self)
@@ -426,7 +427,7 @@ class RemarkableWindow(Window):
                 self.text_buffer.end_not_undoable_action()
             else:
                 # A file is already open. Load the selected file in a new Remarkable process
-                subprocess.Popen(["remarkable", selected_file])
+                subprocess.Popen([sys.argv[0], selected_file])
         
         elif response == Gtk.ResponseType.CANCEL:
             # The user has clicked cancel
@@ -1425,7 +1426,7 @@ class RemarkableWindow(Window):
 
     def on_menuitem_markdown_tutorial_activate(self, widget):
         tutorial_path = self.media_path  + "MarkdownTutorial.md"
-        subprocess.Popen(["remarkable", tutorial_path])
+        subprocess.Popen([sys.argv[0], tutorial_path])
 
     def on_menuitem_homepage_activate(self, widget):
         webbrowser.open_new_tab("http://remarkableapp.github.io")

--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -711,8 +711,12 @@ class RemarkableWindow(Window):
             start, end = self.text_buffer.get_selection_bounds()
             text = self.text_buffer.get_text(start, end, True)
             self.clipboard.set_text(text, -1)
-        elif self.live_preview.can_copy_clipboard():
-            self.live_preview.copy_clipboard()
+        else:
+            self.live_preview.can_execute_editing_command(WebKit2.EDITING_COMMAND_COPY, None, self.execute_copy_command, None)
+
+    def execute_copy_command(self, source, result, user_data):
+        if self.live_preview.can_execute_editing_command_finish(result):
+            self.live_preview.execute_editing_command(WebKit2.EDITING_COMMAND_COPY)
 
     def on_menuitem_paste_activate(self, widget):
         text = self.clipboard.wait_for_text()

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: remarkable
+version: git
+summary: Remarkable editor
+description: |
+   Markdown parser, done right. Commonmark support, extensions, syntax plugins, high speed - all in one. Gulp and metalsmith plugins available. Used by Facebook, Docusaurus and many others!
+confinement: strict
+base: core18
+grade: stable
+
+parts:
+  add-sources:
+    plugin: dump
+    source: .
+    override-prime: |
+      sed -i -e 's/Icon=remarkable/Icon=${SNAP}\/data\/media\/remarkable.png/' /root/stage/remarkable.desktop
+      sed -i -e 's/Popen(sys.argv\[0\])/Popen(\[sys.executable, sys.argv\[0\]\])/' /root/stage/remarkable/RemarkableWindow.py
+      sed -i -e 's/Popen(\[sys.argv\[0\]/Popen(\[sys.executable, sys.argv\[0\]/' /root/stage/remarkable/RemarkableWindow.py
+      snapcraftctl prime
+  remarkable:
+    plugin: python
+    python-version: python3
+    source: .
+    stage-packages:
+      - wkhtmltopdf
+      - python3-gi
+      - python3-bs4
+      - python3-markdown
+      - libqt5webkit5
+      - libqt5qml5
+      - libqt5quick5
+      - libqt5sensors5
+      - libqt5webchannel5
+      - libqt5positioning5
+      - gir1.2-webkit-3.0
+      - gir1.2-gtksource-3.0
+      - python3-gtkspellcheck
+apps:
+  remarkable:
+    command: usr/bin/python3 $SNAP/bin/remarkable
+    environment:
+      PYTHONPATH: $SNAP/remarkable:$SNAP/remarkable_lib
+      PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/lib:$PATH
+      LD_LIBRARY_PATH: $SNAP/usr/lib:$LD_LIBRARY_PATH
+    extensions: [gnome-3-28]
+    desktop: remarkable.desktop
+    plugs:
+      - home
+      - desktop
+      - desktop-legacy
+      - x11
+      - wayland
+      - unity7
+      - removable-media
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
       - libqt5sensors5
       - libqt5webchannel5
       - libqt5positioning5
-      - gir1.2-webkit-3.0
+      - gir1.2-webkit2-4.0
       - gir1.2-gtksource-3.0
       - python3-gtkspellcheck
 apps:


### PR DESCRIPTION
On Ubuntu 19.10 Webkit is no longer available.
The package is now gir1.2-webkit2-4.0.
So I upgraded RemarkableWindow to use webkit2.

Note: not sure if there's a equal line to console-message.
I have not seen any distracting messages in the console.
So I removed that line.