### PR TITLE
Create snap for Remarkable

### DIFF
--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -32,6 +32,7 @@ from locale import gettext as _
 from urllib.request import urlopen
 import markdown
 import os
+import sys
 import pdfkit
 import re, subprocess, datetime, os, webbrowser, _thread, sys, locale
 import tempfile
@@ -386,7 +387,7 @@ class RemarkableWindow(Window):
         Launches a new instance of Remarkable
     """
     def new(self, widget):
-        subprocess.Popen("remarkable")
+        subprocess.Popen(sys.argv[0])
 
     def on_menuitem_open_activate(self, widget):
         self.open(self)
@@ -426,7 +427,7 @@ class RemarkableWindow(Window):
                 self.text_buffer.end_not_undoable_action()
             else:
                 # A file is already open. Load the selected file in a new Remarkable process
-                subprocess.Popen(["remarkable", selected_file])
+                subprocess.Popen([sys.argv[0], selected_file])
         
         elif response == Gtk.ResponseType.CANCEL:
             # The user has clicked cancel
@@ -1425,7 +1426,7 @@ class RemarkableWindow(Window):
 
     def on_menuitem_markdown_tutorial_activate(self, widget):
         tutorial_path = self.media_path  + "MarkdownTutorial.md"
-        subprocess.Popen(["remarkable", tutorial_path])
+        subprocess.Popen([sys.argv[0], tutorial_path])
 
     def on_menuitem_homepage_activate(self, widget):
         webbrowser.open_new_tab("http://remarkableapp.github.io")

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: remarkable
+version: git
+summary: Remarkable editor
+description: |
+   Markdown parser, done right. Commonmark support, extensions, syntax plugins, high speed - all in one. Gulp and metalsmith plugins available. Used by Facebook, Docusaurus and many others!
+confinement: strict
+base: core18
+grade: stable
+
+parts:
+  add-sources:
+    plugin: dump
+    source: .
+    override-prime: |
+      sed -i -e 's/Icon=remarkable/Icon=${SNAP}\/data\/media\/remarkable.png/' /root/stage/remarkable.desktop
+      sed -i -e 's/Popen(sys.argv\[0\])/Popen(\[sys.executable, sys.argv\[0\]\])/' /root/stage/remarkable/RemarkableWindow.py
+      sed -i -e 's/Popen(\[sys.argv\[0\]/Popen(\[sys.executable, sys.argv\[0\]/' /root/stage/remarkable/RemarkableWindow.py
+      snapcraftctl prime
+  remarkable:
+    plugin: python
+    python-version: python3
+    source: .
+    stage-packages:
+      - wkhtmltopdf
+      - python3-gi
+      - python3-bs4
+      - python3-markdown
+      - libqt5webkit5
+      - libqt5qml5
+      - libqt5quick5
+      - libqt5sensors5
+      - libqt5webchannel5
+      - libqt5positioning5
+      - gir1.2-webkit-3.0
+      - gir1.2-gtksource-3.0
+      - python3-gtkspellcheck
+apps:
+  remarkable:
+    command: usr/bin/python3 $SNAP/bin/remarkable
+    environment:
+      PYTHONPATH: $SNAP/remarkable:$SNAP/remarkable_lib
+      PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/lib:$PATH
+      LD_LIBRARY_PATH: $SNAP/usr/lib:$LD_LIBRARY_PATH
+    extensions: [gnome-3-28]
+    desktop: remarkable.desktop
+    plugs:
+      - home
+      - desktop
+      - desktop-legacy
+      - x11
+      - wayland
+      - unity7
+      - removable-media
+


### PR DESCRIPTION
This will add a snapcraft.yaml file. 
So users will be able to download the program via
`snap install remarkable`
I have uploaded the program to snapcraft.io and I would be very happy to give you the control of the 
app: [https://snapcraft.io/remarkable/](https://snapcraft.io/remarkable/)