### PR TITLE
gcc is required to build gnome-3-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Remarkable has many features including:
 
 Check out the [homepage](https://remarkableapp.github.io/linux.html) for more details and [screenshots](https://remarkableapp.github.io/linux/screenshots.html).
 
+### Building for development
+
+* Install [snapcraft](https://snapcraft.io/)
+* run `snapcraft --debug` from this directory
+* install in devmode with `sudo snap install --devmode remarkable_xxx`
+
 ### Issues/Bugs/Suggestions
 
 Feel free to report any bugs or make suggestions [here](https://github.com/jamiemcg/Remarkable/issues)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,6 +20,8 @@ parts:
     plugin: python
     python-version: python3
     source: .
+    build-packages:
+      - build-essential
     stage-packages:
       - wkhtmltopdf
       - python3-gi


### PR DESCRIPTION
This fixes snapcraft.yml on Ubuntu 20.04. Building the Gnome extension without gcc throws an error. 

This build also happens to fix the live preview bug also on Ubuntu 20.04 LTS. This is described in #354 and is likely because of new/changed symbols in the system libraries.

This is not tested on any other OS versions.