### PR TITLE
tree.getiterator - update for Python 3.9+

### DIFF
--- a/remarkable_lib/Builder.py
+++ b/remarkable_lib/Builder.py
@@ -89,7 +89,7 @@ class Builder(Gtk.Builder):
         tree = ElementTree()
         tree.parse(filename)
 
-        ele_widgets = tree.getiterator("object")
+        ele_widgets = tree.iter("object")
         for ele_widget in ele_widgets:
             name = ele_widget.attrib['id']
             widget = self.get_object(name)
@@ -111,7 +111,7 @@ class Builder(Gtk.Builder):
             if connections:
                 self.connections.extend(connections)
 
-        ele_signals = tree.getiterator("signal")
+        ele_signals = tree.iter("signal")
         for ele_signal in ele_signals:
             self.glade_handler_dict.update(
             {ele_signal.attrib["handler"]: None})


### PR DESCRIPTION
tree.getiterator() has been deprecated in Python 2.7 and removed in Python 3.9 (see https://docs.python.org/3/whatsnew/3.9.html).

This PR provides the needed changes.