### PR TITLE
Fix syntax warning with Python 3

### DIFF
--- a/pdfkit/source.py
+++ b/pdfkit/source.py
@@ -8,7 +8,7 @@ class Source(object):
         self.source = url_or_file
         self.type = type_
 
-        if self.type is 'file':
+        if self.type is file:
             self.checkFiles()
 
     def isUrl(self):


### PR DESCRIPTION
Should resolve this warning. Not sure what the implication is on other versions of Python.

```
/usr/lib/python3/dist-packages/pdfkit/source.py:11: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.type is 'file':
```