### PR TITLE
RemarkableWindow.py: fix ModuleNotFoundError: No module named 'findBar'

### DIFF
--- a/remarkable/RemarkableWindow.py
+++ b/remarkable/RemarkableWindow.py
@@ -39,7 +39,7 @@ import traceback
 import styles
 import unicodedata
 import warnings
-from findBar import FindBar
+from remarkable.findBar import FindBar
 
 # Check if gtkspellcheck is installed
 try:


### PR DESCRIPTION
Fixes error:
`ModuleNotFoundError: No module named 'findBar'`